### PR TITLE
only create the gl texture once. fixes #7

### DIFF
--- a/webgl-image-filter.js
+++ b/webgl-image-filter.js
@@ -103,8 +103,10 @@ var WebGLImageFilter = window.WebGLImageFilter = function (params) {
 		_resize( image.width, image.height );
 		_drawCount = 0;
 
-		// Create the texture for the input image
-		_sourceTexture = gl.createTexture();
+		// Create the texture for the input image if we haven't yet
+		if (!_sourceTexture)
+			_sourceTexture = gl.createTexture();
+
 		gl.bindTexture(gl.TEXTURE_2D, _sourceTexture);
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);


### PR DESCRIPTION
@phoboslab this was another performance issue I ran into....after 10-20 seconds of running this in a tight animation loop, the gpu would take something like 250ms to render. I think this is due to the fact that we are creating a new gl texture unnecessarily on each call. This seems to help quite a bit.