### PR TITLE
Add 'blend' filter to overlay an image with a blending mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,9 +65,19 @@ filter.apply(inputImage);
 ### Filters ###
 
 #### Main filters ####
-- `colorMatrix( matrix , amount=1)` apply a the 5x5 color matrix (`Array[20]`), similar to Flash's ColorMatrixFilter
+- `colorMatrix( matrix , amount=1)` apply a 5x5 color matrix (`Array[20]`), similar to Flash's ColorMatrixFilter
 - `convolution( matrix )` apply a 3x3 convolution matrix (`Array[9]`)
 - `blur( radius )` blur with radius in pixels
+- `blend( image, mode, amount=1 )` overlays an image or canvas using the specified blending mode. Available modes are:
+  * normal
+  * add
+  * multiply
+  * screen
+  * overlay
+  * darken
+  * lighten
+  * exclusion
+  * color-burn
 
 
 #### Presets using the main filters ####

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ filter.apply(inputImage);
 ### Filters ###
 
 #### Main filters ####
-- `colorMatrix( matrix )` apply a the 5x5 color matrix (`Array[20]`), similar to Flash's ColorMatrixFilter
+- `colorMatrix( matrix , amount=1)` apply a the 5x5 color matrix (`Array[20]`), similar to Flash's ColorMatrixFilter
 - `convolution( matrix )` apply a 3x3 convolution matrix (`Array[9]`)
 - `blur( radius )` blur with radius in pixels
 
@@ -77,12 +77,12 @@ filter.apply(inputImage);
 - `negative()` invert colors
 - `hue( rotation )` rotate the hue, values are `0-360`
 - `desaturate()` desaturate the image by all channels equally
-- `desaturateLuminance()` desaturate the image taking the natural luminace of each channel into acocunt
-- `sepia()` sepia colors
-- `brownie()` vintage colors
-- `vintagePinhole()` vintage colors
-- `kodachrome()` vintage colors
-- `technicolor()` vintage colors
+- `desaturateLuminance( amount=1 )` desaturate the image taking the natural luminance of each channel into account
+- `sepia( amount=1 )` sepia colors
+- `brownie( amount=1 )` vintage colors
+- `vintagePinhole( amount=1 )` vintage colors
+- `kodachrome( amount=1 )` vintage colors
+- `technicolor( amount=1 )` vintage colors
 - `detectEdges()` detect edges
 - `sobelX()` detect edges using a horizontal sobel operator
 - `sobelY()` detect edges using a vertical sobel operator

--- a/webgl-image-filter.js
+++ b/webgl-image-filter.js
@@ -60,6 +60,14 @@ var WebGLProgram = function( gl, vertexSource, fragmentSource ) {
 	}
 };
 
+const identityMatrix = [
+	1, 0, 0, 0, 0,
+	0, 1, 0, 0, 0,
+	0, 0, 1, 0, 0,
+	0, 0, 0, 1, 0,
+];
+
+const weightedAvg = (a, b, w) => a * w + b * (1 - w);
 
 var WebGLImageFilter = window.WebGLImageFilter = function (params) {
 	if (!params)
@@ -287,7 +295,8 @@ var WebGLImageFilter = window.WebGLImageFilter = function (params) {
 	// -------------------------------------------------------------------------
 	// Color Matrix Filter
 
-	_filter.colorMatrix = function( matrix ) {
+	_filter.colorMatrix = function( matrix , amount = 1 ) {
+		matrix = matrix.map((coef, index) => weightedAvg(coef, identityMatrix[index], amount));
 		// Create a Float32 Array and normalize the offset component to 0-1
 		var m = new Float32Array(matrix);
 		m[4] /= 255;
@@ -392,76 +401,76 @@ var WebGLImageFilter = window.WebGLImageFilter = function (params) {
 		]);
 	};
 
-	_filter.desaturateLuminance = function() {
+	_filter.desaturateLuminance = function( amount ) {
 		_filter.colorMatrix([
 			0.2764723, 0.9297080, 0.0938197, 0, -37.1,
 			0.2764723, 0.9297080, 0.0938197, 0, -37.1,
 			0.2764723, 0.9297080, 0.0938197, 0, -37.1,
 			0, 0, 0, 1, 0
-		]);
+		], amount);
 	};
 
-	_filter.sepia = function() {
+	_filter.sepia = function( amount ) {
 		_filter.colorMatrix([
 			0.393, 0.7689999, 0.18899999, 0, 0,
 			0.349, 0.6859999, 0.16799999, 0, 0,
 			0.272, 0.5339999, 0.13099999, 0, 0,
 			0,0,0,1,0
-		]);
+		], amount);
 	};
 
-	_filter.brownie = function() {
+	_filter.brownie = function( amount ) {
 		_filter.colorMatrix([
 			0.5997023498159715,0.34553243048391263,-0.2708298674538042,0,47.43192855600873,
 			-0.037703249837783157,0.8609577587992641,0.15059552388459913,0,-36.96841498319127,
 			0.24113635128153335,-0.07441037908422492,0.44972182064877153,0,-7.562075277591283,
 			0,0,0,1,0
-		]);
+		], amount);
 	};
 
-	_filter.vintagePinhole = function() {
+	_filter.vintagePinhole = function( amount ) {
 		_filter.colorMatrix([
 			0.6279345635605994,0.3202183420819367,-0.03965408211312453,0,9.651285835294123,
 			0.02578397704808868,0.6441188644374771,0.03259127616149294,0,7.462829176470591,
 			0.0466055556782719,-0.0851232987247891,0.5241648018700465,0,5.159190588235296,
 			0,0,0,1,0
-		]);
+		], amount);
 	};
 
-	_filter.kodachrome = function() {
+	_filter.kodachrome = function( amount ) {
 		_filter.colorMatrix([
 			1.1285582396593525,-0.3967382283601348,-0.03992559172921793,0,63.72958762196502,
 			-0.16404339962244616,1.0835251566291304,-0.05498805115633132,0,24.732407896706203,
 			-0.16786010706155763,-0.5603416277695248,1.6014850761964943,0,35.62982807460946,
 			0,0,0,1,0
-		]);
+		], amount);
 	};
 
-	_filter.technicolor = function() {
+	_filter.technicolor = function( amount ) {
 		_filter.colorMatrix([
 			1.9125277891456083,-0.8545344976951645,-0.09155508482755585,0,11.793603434377337,
 			-0.3087833385928097,1.7658908555458428,-0.10601743074722245,0,-70.35205161461398,
 			-0.231103377548616,-0.7501899197440212,1.847597816108189,0,30.950940869491138,
 			0,0,0,1,0
-		]);
+		], amount);
 	};
 
-	_filter.polaroid = function() {
+	_filter.polaroid = function( amount ) {
 		_filter.colorMatrix([
 			1.438,-0.062,-0.062,0,0,
 			-0.122,1.378,-0.122,0,0,
 			-0.016,-0.016,1.483,0,0,
 			0,0,0,1,0
-		]);
+		], amount);
 	};
 
-	_filter.shiftToBGR = function() {
+	_filter.shiftToBGR = function(amount) {
 		_filter.colorMatrix([
 			0,0,1,0,0,
 			0,1,0,0,0,
 			1,0,0,0,0,
 			0,0,0,1,0
-		]);
+		], amount);
 	};
 
 

--- a/webgl-image-filter.js
+++ b/webgl-image-filter.js
@@ -295,6 +295,55 @@ var WebGLImageFilter = window.WebGLImageFilter = function (params) {
 	// -------------------------------------------------------------------------
 	// Color Matrix Filter
 
+	_filter.blend = function( image, mode, amount = 1 ) {
+		const texture = gl.createTexture();
+
+		gl.activeTexture(gl.TEXTURE1);
+		gl.bindTexture(gl.TEXTURE_2D, texture);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+		gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+		gl.activeTexture(gl.TEXTURE0);
+
+		const shader = _filter.blend.SHADER(_filter.blend.modes[mode]);
+		const program = _compileShader(shader);
+		gl.uniform1i(program.uniform.top, 1);
+		gl.uniform1f(program.uniform.amount, amount);
+
+		_draw();
+	};
+
+	const clamp = expr => `max(min(${expr}, 1.0), 0.0)`;
+	_filter.blend.SHADER = formula => [
+		'precision highp float;',
+		'varying vec2 vUv;',
+		'uniform sampler2D top;',
+		'uniform sampler2D texture;',
+		'uniform float amount;',
+		'vec4 unit = vec4(1.0, 1.0, 1.0, 1.0);',
+
+		'void main(void) {',
+			'vec4 a = texture2D(top, vUv);',
+			'vec4 b = texture2D(texture, vUv);',
+			`vec4 col = ${clamp(formula)};`,
+			'gl_FragColor = col * amount + b * (1.0 - amount);',
+		'}',
+	].join('\n');
+
+	_filter.blend.modes = {
+		normal: 'a',
+		add: 'a + b',
+		multiply: 'a * b',
+		screen: '1.0 - (1.0 - a) * (1.0 - b)',
+		overlay: 'b * (b + 2.0 * a * (1.0 - b))',
+		darken: 'min(a, b)',
+		lighten: 'max(a, b)',
+		exclusion: `a + b - ${clamp('(2.0 * b * a)')}`,
+		'color-burn': `unit - ((unit - b) / a)`,
+	};
+
 	_filter.colorMatrix = function( matrix , amount = 1 ) {
 		matrix = matrix.map((coef, index) => weightedAvg(coef, identityMatrix[index], amount));
 		// Create a Float32 Array and normalize the offset component to 0-1


### PR DESCRIPTION
Introduces a number of blending modes: normal, add, multiply, screen,
overlay, darken, lighten, exclusion and color-burn.

Example usage:

```javascript
// Creating overlay canvas
const cv = document.createElement('canvas');
cv.width = img.width;
cv.height = img.height;
const ctx = cv.getContext('2d');
// Creating cyan -> yellow radial gradient on the canvas
const gradient = ctx.createRadialGradient(
  cv.width/2, cv.height/2, 0,
  cv.width/2, cv.height/2, Math.hypot(cv.width, cv.height)/2
);
gradient.addColorStop(0, 'cyan');
gradient.addColorStop(1, 'yellow');
ctx.fillStyle = gradient;
ctx.fillRect(0, 0, cv.width, cv.height);
// Applying the gradient canvas as an overlay on an image
const glFilter = new WebGLImageFilter({canvas});
glFilter.addFilter('blend', cv, 'overlay', 0.5);
glFilter.apply(img);
```
result:
<img src="https://i.imgur.com/ykulPKK.jpg">