### PR TITLE
Use texSubImage2D in apply after first apply to improve performance

### DIFF
--- a/webgl-image-filter.js
+++ b/webgl-image-filter.js
@@ -98,6 +98,8 @@ var WebGLImageFilter = window.WebGLImageFilter = function (params) {
 	this.reset = function() {
 		_filterChain = [];
 	};
+
+	var applied = false;
 	
 	this.apply = function( image ) {
 		_resize( image.width, image.height );
@@ -112,7 +114,12 @@ var WebGLImageFilter = window.WebGLImageFilter = function (params) {
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST); 
-		gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+		if (!applied) {
+			gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+			applied = true;
+		} else {
+			gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, image);
+		}
 
 		// No filters? Just draw
 		if( _filterChain.length == 0 ) {


### PR DESCRIPTION
`texImage2D` in `apply` creates a new object every time. Used `texSubImage2D` to improve performance by 90%.

Reference: https://stackoverflow.com/questions/12922846/uploading-texture-very-slow-in-opengl